### PR TITLE
fix overflow

### DIFF
--- a/pdf_print.cc
+++ b/pdf_print.cc
@@ -1223,7 +1223,7 @@ void new_xref_entry(const int offset)
 void pdf_print::file_xref()
 {
   xref_entry *u;
-  char tstring[20];
+  char tstring[28];
 
   pr_out->PutString("xref\n");
   sprintf (tstring, "%d %d\n", 0, xref_count);


### PR DESCRIPTION
fix for warning:
```
pdf_print.cc:1223:6: warning: ‘sprintf’ writing a terminating nul past the end of the destination [-Wformat-overflow=]
 void pdf_print::file_xref()
      ^~~~~~~~~
pdf_print.cc:1238:13: note: ‘sprintf’ output between 21 and 28 bytes into a destination of size 20
     sprintf (tstring, "%010d %05d %c \n", u->byte_offset, u->generation, u->use);
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```