### PR TITLE
change header declarations to fix compile errors on macos

### DIFF
--- a/pdf.h
+++ b/pdf.h
@@ -43,5 +43,11 @@
 #define PHRTIE  0x0034
 #define P_S_RED 0x0035
 #define P_U_RED 0x0036
+#define PWTIE   0x0037
+#define NTIE    0x0038
+#define P_S_BLUE 0x0039
+#define P_U_BLUE 0x0040
+#define PERFECT 0x0041
+#define IMPERFECT 0x0042
 #define OTHER   0x0200
 

--- a/print.h
+++ b/print.h
@@ -105,6 +105,8 @@ class print {
     virtual int ps_top() { return( 0);}
     virtual int get_page_number()= 0;
     virtual void comment(const char *string) = 0;
+    virtual void perfect() = 0;
+    virtual void imperfect() = 0;
     void set_highlight() { highlight = On;}
     void clear_highlight() { highlight = Off;}
     void gray_highlight() { highlight_type = Gray;}

--- a/ps.h
+++ b/ps.h
@@ -48,5 +48,6 @@
 #define P_S_BLUE 0x0039
 #define P_U_BLUE 0x0040
 #define PERFECT 0x0041
+#define IMPERFECT 0x0042
 #define OTHER   0x0200
 

--- a/ps_print.h
+++ b/ps_print.h
@@ -86,6 +86,7 @@ public:
   void set_slur_depth(double depth);
   double get_slur_depth();
   void perfect();
+  void imperfect();
 };
 #endif /* _PS_PRINT_ */
 


### PR DESCRIPTION
I needed to make these updates to get it to compile on macOS 15.3.1, XCode 16.2.

```
$ uname -m -r -s -v
Darwin 24.3.0 Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:16 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6000 arm64

$ c++ --version
Apple clang version 16.0.0 (clang-1600.0.26.6)
Target: arm64-apple-darwin24.3.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

```
