### PR TITLE
Fix -autoKey

### DIFF
--- a/getsys.cc
+++ b/getsys.cc
@@ -260,8 +260,6 @@ int getsystem(file_in *fi, i_buf *ib, struct file_info *f,char buf[])
       // printf("getsys.cc:   ->%s", buf);
       for (i=1;i<5;i++) {
 	c = buf[i];
-	if (c == '\n' || c=='\r'|| c == 0) break;  // wbc jan 2025 mostly 0x0d
-	// else printf("getsys.cc: %c\n", c);
 	if (c == '!')  hushbar++;
 	else if (c == 'X' && buf[2] == 'Q') nocountdimbar=1;
 	else if (c == 'Q' && buf[2] == 'X') nocountdimbar=1;

--- a/getsys.cc
+++ b/getsys.cc
@@ -255,11 +255,16 @@ int getsystem(file_in *fi, i_buf *ib, struct file_info *f,char buf[])
       return(2);
     case 'b':
       /* barline */
+      if ((cur_chord < 2) && cur_key && (f->m_flags & AUTOKEY)) {
+	Key=1;
+      }
       /* Jan 2021 wbc added code for QX and XQ for uncounted gray barline */
       i = strlen(buf);
       // printf("getsys.cc:   ->%s", buf);
       for (i=1;i<5;i++) {
 	c = buf[i];
+	if (c == '\n' || c=='\r'|| c == 0) break;  // wbc jan 2025 mostly 0x0d
+	// else printf("getsys.cc: %c\n", c);
 	if (c == '!')  hushbar++;
 	else if (c == 'X' && buf[2] == 'Q') nocountdimbar=1;
 	else if (c == 'Q' && buf[2] == 'X') nocountdimbar=1;
@@ -280,15 +285,14 @@ int getsystem(file_in *fi, i_buf *ib, struct file_info *f,char buf[])
 					  "Text %c %d after a barline (b), system %d chord %d\n",
 					  (void *)((int)c) , (void *)((int)c) ,
 					  (void *)f->cur_system, (void *)cur_chord);
-	    
-	if ((cur_chord < 2) && cur_key && (f->m_flags & AUTOKEY)) {
-	  Key=1;
-	}
 	if (c == NEWLINE || c == 0 || c == 0x0a || c == 0x0d) break; // wbc jan 2025 mostly 0x0d
       }
       barline++;
       break;
     case 'B':
+      if ((cur_chord < 2) && cur_key && (f->m_flags & AUTOKEY)) {
+	Key=1;
+      }
       if (buf[1] == NEWLINE || buf[1] == '!') {
 	BARline++;
 	if ((c = buf[1]) == '!') hushbar++;


### PR DESCRIPTION
-autoKey seems to have been broken since Jan 2025.  When parsing "b\n" in getsys.cc, the newline test on line 263 exits the for loop (which starts on line 261) but without executing the code to set Key = 1 on line 287.  This prevents the autoKey action at the start of the system.  My fix is to delete line 263 (and the now redundant 264).

Test tab file

[autokey.tab.zip](https://github.com/user-attachments/files/21949097/autokey.tab.zip)
